### PR TITLE
Fix installation error due to metro-react-native-babel-preset not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "husky": "^4.0.1",
     "jest": "^25.1.0",
+    "metro-react-native-babel-preset": "^0.59.0",
     "prettier": "^1.19.1",
     "release-it": "^12.6.3",
     "typescript": "^3.7.5",


### PR DESCRIPTION
Please merge this fix after merging [react-native-proximiio PR](https://github.com/proximiio/react-native-proximiio/pull/1) as the same fix is required in both repositories.